### PR TITLE
fix: editing item missing mountFormComponentAction

### DIFF
--- a/resources/views/components/item.blade.php
+++ b/resources/views/components/item.blade.php
@@ -49,7 +49,7 @@
                     'cursor-default' => $disabled || !$editable,
                 ])
                 @if ($editable)
-                wire:click="mountFormComponentAction(@js($statePath), 'edit', @js($mountArgs))"
+                wire:click="{{ $editAction->arguments($mountArgs)->getLivewireClickHandler() }}"
                 @endif>
                 <span>{{ $item[$labelKey] }}</span>
             </button>


### PR DESCRIPTION
Use edit action for editing item with passed args